### PR TITLE
feat: render level complete modal

### DIFF
--- a/lib/features/game/UI/overlay_builder.dart
+++ b/lib/features/game/UI/overlay_builder.dart
@@ -1,6 +1,7 @@
 import 'package:brick_breaker/features/game/components/forge2d_game_world.dart';
 import 'package:brick_breaker/features/game/constants.dart';
 import 'package:brick_breaker/utils/constants.dart';
+import 'package:brick_breaker/utils/widgets/modal.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -22,7 +23,7 @@ class OverlayBuilder {
     debugPrint(gameWorld.gameState.toString());
 
     final message =
-        (gameWorld.gameState == GameState.won) ? 'Yay, You won!' : 'Game over';
+        (gameWorld.gameState == GameState.won) ? const Modal() : const Text('Game over');
     return PostGameOverlay(message: message, game: gameWorld);
   }
 }
@@ -47,7 +48,7 @@ class PreGameOverlay extends StatelessWidget {
 class PostGameOverlay extends StatelessWidget {
   const PostGameOverlay({super.key, required this.message, required this.game});
 
-  final String message;
+  final dynamic message;
   final Forge2dGameWorld game;
   @override
   Widget build(BuildContext context) {
@@ -55,12 +56,25 @@ class PostGameOverlay extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text(
-            message,
-            style: GoogleFonts.russoOne(
-                color: AppColors.greenColor,
-                fontSize: 24,
-                fontWeight: FontWeight.w400),
+           Builder(
+            builder: (BuildContext context) {
+              if (message is String) {
+                // If message is a String, create a Text widget
+                return Text(
+                  message,
+                  style: GoogleFonts.russoOne(
+                      color: AppColors.greenColor,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w400),
+                );
+              } else if (message is Widget) {
+                // If message is a Widget, return it directly
+                return message;
+              } else {
+                // Handle other types of messages if needed
+                return Container();
+              }
+            },
           ),
           const SizedBox(
             height: 24,


### PR DESCRIPTION
## Description

This pull request brings a series of improvements to the project. When the user wins a game, a modal is rendered to show that a specific level is complete. 

## Related Issue
This pull request addresses the issue of the game not corresponding to the Figma UI design.

## Motivation and Context

These updates are essential to elevate the project's visual appeal.

Screenshots to show the working Modal: 

<img width="417" alt="Screenshot 2023-10-19 at 08 12 21" src="https://github.com/hngx-org/team-rainbow_troops-breakout-revival/assets/28736856/6975c156-a44c-4194-954e-5d29d2e6fb54">




## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 



